### PR TITLE
Use proper Docusaurus url `https://ambari.apache.org`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Apache Ambari',
   tagline: 'The Apache Ambari project is aimed at making Hadoop management simpler by developing software for provisioning, managing, and monitoring Apache Hadoop clusters. Ambari provides an intuitive, easy-to-use Hadoop management web UI backed by its RESTful APIs.',
-  url: 'https://your-docusaurus-test-site.com',
+  url: 'https://ambari.apache.org',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
Docusaurus maintainer here

You are using the wrong site config url, leading to bad canonical URLs that are important for SEO. Using the right value will improve site SEO
